### PR TITLE
Fix object deletion race

### DIFF
--- a/lib/acto.cpp
+++ b/lib/acto.cpp
@@ -106,12 +106,8 @@ void actor::set_handler(const std::type_index& type,
 }
 
 void destroy(actor_ref& object) {
-  if (core::object_t* const obj = object.m_object) {
-    object.m_object = nullptr;
-    if (core::runtime_t::instance()->release(obj) > 0) {
-      core::runtime_t::instance()->deconstruct_object(obj);
-    }
-  }
+  actor_ref object_ref(std::move(object));
+  core::runtime_t::instance()->deconstruct_object(object_ref.m_object);
 }
 
 void join(const actor_ref& obj) {

--- a/lib/worker.cpp
+++ b/lib/worker.cpp
@@ -95,7 +95,8 @@ bool worker_t::process() {
       break;
     }
 
-    if (runtime_t::instance()->release(obj)) {
+    {
+      actor_ref obj_ref(obj, false);
       if (need_delete) {
         slots_->push_delete(obj);
       }


### PR DESCRIPTION
We can't be sure object is alive after release call, because another reference can be released in parallel thread.
To fix this race hold reference during explicit deconstruction.