### PR TITLE
Fix race in worker_t

### DIFF
--- a/lib/worker.cpp
+++ b/lib/worker.cpp
@@ -41,13 +41,14 @@ void worker_t::wakeup() {
 }
 
 void worker_t::execute() {
-  while (active_) {
+  while (true) {
+    event_.wait(); // Cond: (object_ != 0) || (active_ == false)
+    if (!active_) {
+      return;
+    }
     if (!process()) {
       slots_->push_idle(this);
     }
-
-    // Wait for new tasks.
-    event_.wait(); // Cond: (object_ != 0) || (active_ == false)
   }
 }
 


### PR DESCRIPTION
Do not let `process()` to perform unnecessary `object_` read before waiting for `event_`, because `object_` is written concurrently by `assign`.
Problem was found by ThreadSanitizer.