### PR TITLE
Unset object_t::scheduled after all messages were processed

### DIFF
--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -40,6 +40,10 @@ struct binding_context_t {
       while (auto msg = (*ai)->select_message()) {
         runtime->handle_message(*ai, std::move(msg));
       }
+      {
+        std::lock_guard<std::mutex> g((*ai)->cs);
+        (*ai)->scheduled = false;
+      }
       if (need_delete) {
         runtime->deconstruct_object(*ai);
       }


### PR DESCRIPTION
`object_t::scheduled` for an actor bound to a thread must be unset to allow the actor to be destroyed.